### PR TITLE
feat: add meta frameworks support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "activationEvents": [
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
+    "onLanguage:vue",
+    "onLanguage:svelte",
+    "onLanguage:astro",
+    "onLanguage:mdx",
     "onLanguage:type"
   ],
   "main": "./dist/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,12 @@ function getMetaFrameworkLanguages() {
     for (const language of packageJSON.contributes?.languages ?? []) {
       for (const grammar of packageJSON.contributes.grammars ?? []) {
         const embeddedLanguages = new Set<string>(Object.values(grammar.embeddedLanguages ?? []));
-        if (embeddedLanguages.has('typescript') || embeddedLanguages.has('typescriptreact')) {
+        if (
+          embeddedLanguages.has("typescript")
+          || embeddedLanguages.has("typescriptreact")
+          || embeddedLanguages.has("javascript")
+          || embeddedLanguages.has("javascriptreact")
+        ) {
           metaFrameworkLanguages.push(language.id);
         }
       }


### PR DESCRIPTION
~~Search meta framework languages that support typescript embedded language based on grammars property in language extension package.json.~~ Refactored to simpler dynamic registration.

For people who need to use this PR in advance (unzip it and drag to VSCode extension sidebar):
[pretty-ts-errors-0.2.4-pr2.vsix.zip](https://github.com/yoavbls/pretty-ts-errors/files/11215170/pretty-ts-errors-0.2.4-pr2.vsix.zip)
