### PR TITLE
refactor: decoupling vscode, prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
   "dependencies": {
     "lz-string": "^1.4.4",
     "prettier": "^2.8.7",
-    "ts-dedent": "^2.2.0"
+    "ts-dedent": "^2.2.0",
+    "vscode-languageclient": "^8.1.0",
+    "vscode-languageserver-types": "^3.17.3",
+    "vscode-uri": "^3.0.7"
   }
 }

--- a/src/components/consts/knownErrorNumbers.ts
+++ b/src/components/consts/knownErrorNumbers.ts
@@ -1,4 +1,4 @@
-import { Diagnostic } from "vscode";
+import { Diagnostic } from "vscode-languageserver-types";
 
 /** Should be updated from:
  * https://typescript.tv/errors

--- a/src/components/title.ts
+++ b/src/components/title.ts
@@ -1,4 +1,4 @@
-import { Diagnostic } from "vscode";
+import { Diagnostic } from "vscode-languageserver-types";
 import { compressToEncodedURIComponent, d } from "../utils";
 import { KNOWN_ERROR_NUMBERS } from "./consts/knownErrorNumbers";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,9 @@ import {
 import { formatDiagnostic } from "./format/formatDiagnostic";
 import { hoverProvider } from "./provider/hoverProvider";
 import { uriStore } from "./provider/uriStore";
-import { has, prettify } from "./utils";
+import { has } from "./utils";
 import { createConverter } from "vscode-languageclient/lib/common/codeConverter";
+import { format } from "prettier";
 
 export function activate(context: ExtensionContext) {
   const registeredLanguages = new Set<string>();
@@ -70,4 +71,13 @@ export function activate(context: ExtensionContext) {
       });
     })
   );
+}
+
+function prettify(text: string) {
+  return format(text, {
+    parser: "typescript",
+    printWidth: 60,
+    singleAttributePerLine: false,
+    arrowParens: "avoid",
+  });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,8 @@ export function activate(context: ExtensionContext) {
           )
           .forEach(async (diagnostic) => {
 
+            // formatDiagnostic converts message based on LSP Diagnostic type, not VSCode Diagnostic type, so it can be used in other IDEs.
+            // Here we convert VSCode Diagnostic to LSP Diagnostic to make formatDiagnostic recognize it.
             const markdownString = new MarkdownString(formatDiagnostic(converter.asDiagnostic(diagnostic), prettify));
 
             markdownString.isTrusted = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,10 +8,12 @@ import {
 import { formatDiagnostic } from "./format/formatDiagnostic";
 import { hoverProvider } from "./provider/hoverProvider";
 import { uriStore } from "./provider/uriStore";
-import { has } from "./utils";
+import { has, prettify } from "./utils";
+import { createConverter } from "vscode-languageclient/lib/common/codeConverter";
 
 export function activate(context: ExtensionContext) {
   const registeredLanguages = new Set<string>();
+  const converter = createConverter();
 
   context.subscriptions.push(
     languages.onDidChangeDiagnostics(async (e) => {
@@ -32,9 +34,15 @@ export function activate(context: ExtensionContext) {
               : false
           )
           .forEach(async (diagnostic) => {
+
+            const markdownString = new MarkdownString(formatDiagnostic(converter.asDiagnostic(diagnostic), prettify));
+
+            markdownString.isTrusted = true;
+            markdownString.supportHtml = true;
+
             items.push({
               range: diagnostic.range,
-              contents: [formatDiagnostic(diagnostic)],
+              contents: [markdownString],
             });
             hasTsDiagnostic = true;
           });

--- a/src/format/embedSymbolLinks.ts
+++ b/src/format/embedSymbolLinks.ts
@@ -1,4 +1,5 @@
-import { Diagnostic } from "vscode";
+import { Diagnostic } from "vscode-languageserver-types";
+import { URI } from "vscode-uri";
 
 export function embedSymbolLinks(diagnostic: Diagnostic): Diagnostic {
   if (
@@ -17,7 +18,7 @@ export function embedSymbolLinks(diagnostic: Diagnostic): Diagnostic {
     ...diagnostic,
     message: diagnostic.message.replaceAll(
       symbol,
-      `${symbol} <a href="${ref.location.uri.path}#${
+      `${symbol} <a href="${URI.parse(ref.location.uri).path}#${
         ref.location.range.start.line + 1
       },${
         ref.location.range.start.character + 1

--- a/src/format/formatDiagnostic.ts
+++ b/src/format/formatDiagnostic.ts
@@ -1,22 +1,17 @@
-import { Diagnostic, MarkdownString } from "vscode";
+import { Diagnostic } from "vscode-languageserver-types";
 import { title } from "../components";
 import { d } from "../utils";
 import { embedSymbolLinks } from "./embedSymbolLinks";
 import { formatDiagnosticMessage } from "./formatDiagnosticMessage";
 import { identSentences } from "./identSentences";
 
-export function formatDiagnostic(diagnostic: Diagnostic) {
+export function formatDiagnostic(diagnostic: Diagnostic, format: (type: string) => string) {
   const newDiagnostic = embedSymbolLinks(diagnostic);
 
-  const markdownString = new MarkdownString(d/*html*/ `
+  return d/*html*/ `
     ${title(newDiagnostic)}
     <span>
-    ${formatDiagnosticMessage(identSentences(newDiagnostic.message))}
+    ${formatDiagnosticMessage(identSentences(newDiagnostic.message), format)}
     </span>
-  `);
-
-  markdownString.isTrusted = true;
-  markdownString.supportHtml = true;
-
-  return markdownString;
+  `;
 }

--- a/src/format/formatTypeBlock.ts
+++ b/src/format/formatTypeBlock.ts
@@ -3,10 +3,9 @@ import {
   multiLineCodeBlock,
   unstyledCodeBlock,
 } from "../components";
-import { prettify } from "../utils";
 import { addMissingParentheses } from "./addMissingParentheses";
 
-export function formatTypeBlock(prefix: string, type: string) {
+export function formatTypeBlock(prefix: string, type: string, format: (type: string) => string) {
   // Return a simple code block if it's just a parenthasis
   if (type.match(/^(\[\]|\{\})$/)) {
     return `${prefix} ${unstyledCodeBlock(type)}`;
@@ -21,7 +20,7 @@ export function formatTypeBlock(prefix: string, type: string) {
     return `${prefix} ${inlineCodeBlock(type, "type")}`;
   }
 
-  const prettyType = prettifyType(type);
+  const prettyType = convertToOriginalType(prettifyType(convertToValidType(type), format));
 
   if (prettyType.includes("\n")) {
     return `${prefix}: ${multiLineCodeBlock(prettyType, "type")}`;
@@ -32,16 +31,11 @@ export function formatTypeBlock(prefix: string, type: string) {
 /**
  * Try to make type prettier with prettier
  */
-function prettifyType(type: string) {
+function prettifyType(type: string, format: (type: string) => string) {
   try {
     // Wrap type with valid statement, format it and extract the type back
     return convertToOriginalType(
-      prettify(convertToValidType(type), {
-        parser: "typescript",
-        printWidth: 60,
-        singleAttributePerLine: false,
-        arrowParens: "avoid",
-      })
+      format(convertToValidType(type))
     );
   } catch (e) {
     return type;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,6 @@
 // We re-export modules to be able to replace/change them easily across all the usages
 export { compressToEncodedURIComponent } from "lz-string";
-import { format } from "prettier";
 import dedent from "ts-dedent";
-
-export function prettify(text: string) {
-  return format(text, {
-    parser: "typescript",
-    printWidth: 60,
-    singleAttributePerLine: false,
-    arrowParens: "avoid",
-  });
-}
 
 /**
  * d stands for dedent.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,16 @@
 // We re-export modules to be able to replace/change them easily across all the usages
 export { compressToEncodedURIComponent } from "lz-string";
-export { format as prettify } from "prettier";
+import { format } from "prettier";
 import dedent from "ts-dedent";
+
+export function prettify(text: string) {
+  return format(text, {
+    parser: "typescript",
+    printWidth: 60,
+    singleAttributePerLine: false,
+    arrowParens: "avoid",
+  });
+}
 
 /**
  * d stands for dedent.


### PR DESCRIPTION
Decouple vscode, prettier from components/*, format/*, now format scripts can be easily converted to a separate monorepo sub-package.

This PR only deals with decoupling, converting monorepo should be done independently so as not to conflict with other PRs.