### PR TITLE
add support for chinese lang

### DIFF
--- a/src/format/formatDiagnosticMessage.ts
+++ b/src/format/formatDiagnosticMessage.ts
@@ -20,7 +20,7 @@ export const formatDiagnosticMessage = (message: string, format: (type: string) 
   message
     // format declare module snippet
     .replaceAll(
-      /'(declare module )'(.*)';'/g,
+      /['“](declare module )['”](.*)['“];['”]/g,
       (_: string, p1: string, p2: string) =>
         formatTypeScriptBlock(_, `${p1} "${p2}"`)
     )
@@ -36,48 +36,48 @@ export const formatDiagnosticMessage = (message: string, format: (type: string) 
     )
     // Format type pairs
     .replaceAll(
-      /(types) '(.*?)' and '(.*?)'[\.]?/gi,
+      /(types) ['“](.*?)['”] and ['“](.*?)['”][\.]?/gi,
       (_: string, p1: string, p2: string, p3: string) =>
         `${formatTypeBlock(p1, p2, format)} and ${formatTypeBlock("", p3, format)}`
     )
     // Format type annotation options
     .replaceAll(
-      /type annotation must be '(.*?)' or '(.*?)'[\.]?/gi,
+      /type annotation must be ['“](.*?)['”] or ['“](.*?)['”][\.]?/gi,
       (_: string, p1: string, p2: string, p3: string) =>
         `${formatTypeBlock(p1, p2, format)} or ${formatTypeBlock("", p3, format)}`
     )
     .replaceAll(
-      /(Overload \d of \d), '(.*?)', /gi,
+      /(Overload \d of \d), ['“](.*?)['”], /gi,
       (_, p1: string, p2: string) => `${p1}${formatTypeBlock("", p2, format)}`
     )
     // format simple strings
-    .replaceAll(/^'"[^"]*"'$/g, formatTypeScriptBlock)
+    .replaceAll(/^['“]"[^"]*"['”]$/g, formatTypeScriptBlock)
     // Format types
     .replaceAll(
-      /(type|type alias|interface|module|file|file name) '(.*?)'[\.]?/gi,
+      /(type|type alias|interface|module|file|file name) ['“](.*?)['”][\.]?/gi,
       (_, p1: string, p2: string) => formatTypeOrModuleBlock(_, p1, p2, format)
     )
     // Format reversed types
     .replaceAll(
-      /(.*)'([^>]*)' (type|interface|return type|file|module)/gi,
+      /(.*)['“]([^>]*)['”] (type|interface|return type|file|module)/gi,
       (_: string, p1: string, p2: string, p3: string) =>
         `${p1}${formatTypeOrModuleBlock(_, "", p2, format)} ${p3}`
     )
     // Format simple types that didn't captured before
     .replaceAll(
-      /'((void|null|undefined|any|boolean|string|number|bigint|symbol)(\[\])?)'/g,
+      /['“]((void|null|undefined|any|boolean|string|number|bigint|symbol)(\[\])?)['”]/g,
       formatSimpleTypeBlock
     )
     // Format some typescript key words
     .replaceAll(
-      /'(import|export|require|in|continue|break|let|false|true|const|new|throw|await|for await|[0-9]+)( ?.*?)'/g,
+      /['“](import|export|require|in|continue|break|let|false|true|const|new|throw|await|for await|[0-9]+)( ?.*?)['”]/g,
       (_: string, p1: string, p2: string) =>
         formatTypeScriptBlock(_, `${p1}${p2}`)
     )
     // Format return values
     .replaceAll(
-      /(return|operator) '(.*?)'/gi,
+      /(return|operator) ['“](.*?)['”]/gi,
       (_, p1: string, p2: string) => `${p1} ${formatTypeScriptBlock("", p2)}`
     )
     // Format regular code blocks
-    .replaceAll(/'(.*?)'/g, (_: string, p1: string) => unstyledCodeBlock(p1));
+    .replaceAll(/['“](.*?)['”]/g, (_: string, p1: string) => unstyledCodeBlock(p1));


### PR DESCRIPTION
when the extension of `Chinese (Simplified) (简体中文) Language Pack for Visual Studio Code` installed, it use `“”` to wrap the code in error hint. 

add support for it