### PR TITLE
feat: Add glimmer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and [more](https://www.youtube.com/playlist?list=PL0rc4JAdEsVpOriHzlAG7KUnhKIK9c
 - JSDoc type errors (in `.js` and `.jsx` files)
 - React, Solid and Qwik errors (in `.tsx` and `.mdx` files)
 - Astro, Svelte and Vue files when TypeScript is enabled (in `.astro`, `.svelte` and `.vue` files)
-- Ember and Glimmer errors (in `.gjs` and `.gts` files)
+- Ember and Glimmer TypeScript errors and template issues reported by Glint (in `.hbs`, `.gjs`, and `.gts` files)
   
   
 ## Installation

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ and [more](https://www.youtube.com/playlist?list=PL0rc4JAdEsVpOriHzlAG7KUnhKIK9c
 - JSDoc type errors (in `.js` and `.jsx` files)
 - React, Solid and Qwik errors (in `.tsx` and `.mdx` files)
 - Astro, Svelte and Vue files when TypeScript is enabled (in `.astro`, `.svelte` and `.vue` files)
+- Ember and Glimmer errors (in `.gjs` and `.gts` files)
   
   
 ## Installation

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "onLanguage:astro",
     "onLanguage:svelte",
     "onLanguage:vue",
-    "onLanguage:mdx"
+    "onLanguage:mdx",
+    "onLanguage:glimmer-js",
+    "onLanguage:glimmer-ts"
   ],
   "main": "./dist/extension.js",
   "browser": "./dist/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ export function activate(context: ExtensionContext) {
         diagnostics
           .filter((diagnostic) =>
             diagnostic.source
-              ? has(["ts", "deno-ts", "js"], diagnostic.source)
+              ? has(["ts", "deno-ts", "js", "glint"], diagnostic.source)
               : false
           )
           .forEach(async (diagnostic) => {


### PR DESCRIPTION
Adds support for `.gjs` and `.gts` file formats. [Glimmer](https://glimmerjs.com/) `<template>` tag components are the new format which power Ember.js. References:

RFC: https://rfcs.emberjs.com/id/0779-first-class-component-templates
Component implementation: https://github.com/ember-template-imports/ember-template-imports

Ember diagnostics provided by [Glint](https://github.com/typed-ember/glint) are also added as an input.

**Local test**

Before:

<img width="524" alt="Screenshot 2023-10-23 at 19 22 54" src="https://github.com/yoavbls/pretty-ts-errors/assets/10243652/00ede6c5-e828-4b49-a819-d8deb221b3c2">


After:

<img width="719" alt="Screenshot 2023-10-23 at 19 22 44" src="https://github.com/yoavbls/pretty-ts-errors/assets/10243652/c037b4fe-6d77-491a-9ad6-94c045e19358">

