### PR TITLE
Add `ts-plugin` to diagnostic sources

### DIFF
--- a/examples/errors.vue
+++ b/examples/errors.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { RouterView } from "vue-router";
+
+const x = [1, 2, 3, "4"];
+
+function y(param: number[]) {}
+
+y(x);
+</script>
+<template>
+  <RouterView />
+</template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pretty-ts-errors",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pretty-ts-errors",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "lz-string": "^1.5.0",
         "prettier": "^2.8.8",
@@ -24,7 +24,7 @@
         "@types/vscode": "^1.70.0",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.9",
         "esbuild": "^0.18.17",
         "eslint": "^8.46.0",
         "glob": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Pretty TypeScript Errors",
   "publisher": "YoavBls",
   "description": "Make TypeScript errors prettier and more human-readable in VSCode",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: ExtensionContext) {
             hasTsDiagnostic = true;
           });
 
-        uriStore[uri.path] = items;
+        uriStore[uri.fsPath] = items;
 
         if (hasTsDiagnostic) {
           const editor = window.visibleTextEditors.find(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,10 @@ export function activate(context: ExtensionContext) {
         diagnostics
           .filter((diagnostic) =>
             diagnostic.source
-              ? has(["ts", "deno-ts", "js", "glint"], diagnostic.source)
+              ? has(
+                  ["ts", "ts-plugin", "deno-ts", "js", "glint"],
+                  diagnostic.source
+                )
               : false
           )
           .forEach(async (diagnostic) => {

--- a/src/format/embedSymbolLinks.ts
+++ b/src/format/embedSymbolLinks.ts
@@ -18,7 +18,7 @@ export function embedSymbolLinks(diagnostic: Diagnostic): Diagnostic {
     ...diagnostic,
     message: diagnostic.message.replaceAll(
       symbol,
-      `${symbol} <a href="${URI.parse(ref.location.uri).path}#${
+      `${symbol} <a href="${URI.parse(ref.location.uri).fsPath}#${
         ref.location.range.start.line + 1
       },${
         ref.location.range.start.character + 1

--- a/src/provider/hoverProvider.ts
+++ b/src/provider/hoverProvider.ts
@@ -3,7 +3,7 @@ import { uriStore } from "./uriStore";
 
 export const hoverProvider: HoverProvider = {
   provideHover(document, position) {
-    const itemsInUriStore = uriStore[document.uri.path];
+    const itemsInUriStore = uriStore[document.uri.fsPath];
 
     if (!itemsInUriStore) {
       return null;


### PR DESCRIPTION
In the new official extension of [Vue VSCode plugin](https://marketplace.visualstudio.com/items?itemName=Vue.volar), Hybrid mode is enabled by default,  
which means that a TypeScript LSP Plugin publishes the diagnostics.
We didn't have `ts-plugin` in our diagnostic sources list so I add it. 
and it solved #100 #101 

