### PR TITLE
refactor: use PropertyKey instaed of key list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,8 +31,8 @@ export const has = (
  * inverted as { [value]: key }
  */
 export const invert = <
-  TKey extends string | number | symbol,
-  TValue extends string | number | symbol
+  TKey extends PropertyKey,
+  TValue extends PropertyKey
 >(
   obj: Record<TKey, TValue>
 ): Record<TValue, TKey> => {


### PR DESCRIPTION
we can use `PropertyKey` instead of key list
https://www.totaltypescript.com/concepts/propertykey-type