### PR TITLE
add configuration property to explicitly disable the markdown preview in the Explorer view

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -69,7 +69,7 @@
           "name": "Pretty TypeScript Error",
           "type": "webview",
           "visibility": "collapsed",
-          "when": "config.prettyTsErrors.enableMarkdownPreviewInExplorer"
+          "when": "config.prettyTsErrors.enableMarkdownPreviewInExplorerView"
         }
       ]
     },


### PR DESCRIPTION
Fixes #166 & #164. Or at least gives an option to disable the view.

This PR introduces a simple configuration option to enable/disable the markdown preview in the Explorer view. It is enabled by default, and can be disabled to explicitly opt-out.

<img width="1200" height="480" alt="image" src="https://github.com/user-attachments/assets/6d4e1bef-6371-4c24-a276-1df891d564ab" />

As shown in the issues, when the explorer view is disabled by the user, and its folder view is dragged out of it, it creates weird and user-unfriendly behaviour.

Initially, I assumed the default UI features from VS Code would be enough to disable the view, but multiple people have reported that these don't work as they should. VS Code either forgets to persist the users configuration or it just does not work at all. Having a configuration option allows these users to not have to fight with VS Code and just uncheck a checkbox.
