### PR TITLE
add global tsdown.config to ignore .turbo directories

### DIFF
--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+    ignoreWatch: ['.turbo/']
+})


### PR DESCRIPTION
Should fix #158.

See https://tsdown.dev/reference/api/Interface.UserConfig#ignorewatch and https://tsdown.dev/options/config-file.

Since `tsdown` traverses its parents until it finds a config file, this should work for all packages using `tsdown`.