### PR TITLE
Update log instructions link in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ Type 'number' is not assignable to type 'string'.ts(2322)
 
 ### **Logs**
 
-Add the logs to help debugging what went wrong. See [these instructions](../../docs/vscode-logs.md) on how to find and export the logs.
+Add the logs to help debugging what went wrong. See [these instructions](https://github.com/yoavbls/pretty-ts-errors/blob/main/docs/vscode-logs.md) on how to find and export the logs.
 
 Either add it as an external file or put them in between these `<pre><code>` tags below:
 


### PR DESCRIPTION
We have to use a full link, because issues can be created from both:
- https://github.com/yoavbls/pretty-ts-errors/issues
- https://github.com/yoavbls/pretty-ts-errors/issues/new?template=bug_report.md
