### PR TITLE
fix: pin error focuses the view instead of the view container

### DIFF
--- a/apps/vscode-extension/src/commands/pinError.ts
+++ b/apps/vscode-extension/src/commands/pinError.ts
@@ -21,7 +21,7 @@ export function registerPinError(context: ExtensionContext) {
 
         try {
           await commands.executeCommand(
-            "workbench.view.extension.prettyTsErrors"
+            "prettyTsErrors.sidePanel.focus"
           );
         } catch {}
       })

--- a/apps/vscode-extension/src/commands/pinError.ts
+++ b/apps/vscode-extension/src/commands/pinError.ts
@@ -20,9 +20,7 @@ export function registerPinError(context: ExtensionContext) {
         await viewProvider?.pinDiagnostic(range);
 
         try {
-          await commands.executeCommand(
-            "prettyTsErrors.sidePanel.focus"
-          );
+          await commands.executeCommand("prettyTsErrors.sidePanel.focus");
         } catch {}
       })
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "apps/vscode-extension": {
       "name": "pretty-ts-errors",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@pretty-ts-errors/formatter": "*",
         "@pretty-ts-errors/utils": "*",


### PR DESCRIPTION
## Problem

When clicking "Pin Error" in the tooltip, the command reveals the view container using `workbench.view.extension.prettyTsErrors`. If the user has moved the Pretty TS Errors webview view to a different view container (e.g. the Explorer sidebar), this command focuses the original (now potentially empty) container instead of where the view actually lives — causing an unexpected view switch.

## Fix

Changed to use `prettyTsErrors.sidePanel.focus` which focuses the specific webview view regardless of which container it has been moved to. VS Code automatically generates a `.focus` command for each registered webview view.

## Testing

1. Move the "Pretty Typescript Errors" view to a separate view container (drag it to the Explorer sidebar or secondary sidebar)
2. Focus the Pretty TS Errors view
3. Hover over a TypeScript error and click "Pin Error"
4. The Pretty TS Errors view should remain visible — previously it would switch to the Explorer view

Fixes #182