### PR TITLE
fix: preserve active view when pinning error

### DIFF
--- a/apps/vscode-extension/src/commands/pinError.ts
+++ b/apps/vscode-extension/src/commands/pinError.ts
@@ -1,4 +1,4 @@
-import { commands, type ExtensionContext } from "vscode";
+import { type ExtensionContext } from "vscode";
 import { execute } from "./execute";
 import { tryEnsureRange } from "./validate";
 import { getViewProvider } from "../provider/webviewViewProvider";
@@ -18,12 +18,6 @@ export function registerPinError(context: ExtensionContext) {
 
         const viewProvider = getViewProvider();
         await viewProvider?.pinDiagnostic(range);
-
-        try {
-          await commands.executeCommand(
-            "workbench.view.extension.prettyTsErrors"
-          );
-        } catch {}
       })
     )
   );


### PR DESCRIPTION
## Summary

Fixes #182 — clicking "Pin Error" no longer switches focus to the Explorer view when Pretty TS Errors is in a separate view container.

## Root Cause

After calling `viewProvider.pinDiagnostic()`, the command executed `workbench.view.extension.prettyTsErrors` to focus the panel. In some VS Code configurations (especially when Pretty TS Errors is docked in a custom view container), this command was causing the Explorer view to receive focus instead, hiding the Pretty TS Errors view.

## Fix

Removed the `commands.executeCommand("workbench.view.extension.prettyTsErrors")` call from `pinError.ts`. The pin action itself works correctly without needing to programmatically switch the active view — the user already has the panel visible when they trigger the pin from a hover tooltip.

Also removed the now-unused `commands` import.

## Testing

- Move Pretty TS Errors view to a separate view container
- Focus it
- Hover a TypeScript error to get the tooltip
- Click "Pin Error" — the Pretty TS Errors view remains visible

Closes #182