### PR TITLE
use enabledCommands to limit the commands that can be used in markdown views

### DIFF
--- a/apps/vscode-extension/src/commands/enabledCommands.ts
+++ b/apps/vscode-extension/src/commands/enabledCommands.ts
@@ -1,0 +1,10 @@
+/**
+ * A list of whitelisted commands for the hoverview and webview.
+ */
+export const enabledCommands = [
+  "prettyTsErrors.showErrorInSidebar",
+  "prettyTsErrors.revealSelection",
+  "prettyTsErrors.copyError",
+  "prettyTsErrors.pinError",
+  "prettyTsErrors.unpinError",
+];

--- a/apps/vscode-extension/src/diagnostics.ts
+++ b/apps/vscode-extension/src/diagnostics.ts
@@ -18,6 +18,7 @@ import {
   type FormattedDiagnostic,
 } from "./formattedDiagnosticsStore";
 import { logger } from "./logger";
+import { enabledCommands } from "./commands/enabledCommands";
 
 /**
  * The list of diagnostic sources that pretty-ts-errors supports
@@ -101,8 +102,7 @@ async function getFormattedDiagnostic(
     const formattedDiagnostic = await prettifyDiagnosticForHover(lspDiagnostic);
     const markdownString = new MarkdownString(formattedDiagnostic);
 
-    // TODO: consider using the `{ enabledCommands: string[] }` variant, to only allow whitelisted commands
-    markdownString.isTrusted = true;
+    markdownString.isTrusted = { enabledCommands };
     markdownString.supportHtml = true;
 
     formattedMessage = markdownString;

--- a/apps/vscode-extension/src/provider/markdownWebviewProvider.ts
+++ b/apps/vscode-extension/src/provider/markdownWebviewProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { enabledCommands } from "../commands/enabledCommands";
 
 /**
  * @see https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample
@@ -28,12 +29,7 @@ export class MarkdownWebviewProvider {
 
   getWebviewOptions(): vscode.WebviewOptions {
     return {
-      enableCommandUris: [
-        "prettyTsErrors.revealSelection",
-        "prettyTsErrors.copyError",
-        "prettyTsErrors.pinError",
-        "prettyTsErrors.unpinError",
-      ],
+      enableCommandUris: enabledCommands,
       enableScripts: true,
       enableForms: false,
       localResourceRoots: [this.webviewRootUri],

--- a/apps/vscode-extension/src/provider/selectedTextHoverProvider.ts
+++ b/apps/vscode-extension/src/provider/selectedTextHoverProvider.ts
@@ -9,6 +9,7 @@ import {
 } from "vscode";
 import { createConverter } from "vscode-languageclient/lib/common/codeConverter";
 import { formattedDiagnosticsStore } from "../formattedDiagnosticsStore";
+import { enabledCommands } from "../commands/enabledCommands";
 
 /**
  * Register an hover provider in debug only.
@@ -53,7 +54,7 @@ export function registerSelectedTextHoverProvider(context: ExtensionContext) {
             debugHoverHeader + (await prettifyDiagnosticForHover(lspDiagnostic))
           );
 
-          markdown.isTrusted = true;
+          markdown.isTrusted = { enabledCommands };
           markdown.supportHtml = true;
 
           formattedDiagnosticsStore.set(document.uri.fsPath, [


### PR DESCRIPTION
This PR fixes a TODO comment to use [`isTrusted: { enabledCommands: string[] }`](https://code.visualstudio.com/api/references/vscode-api#MarkdownString.isTrusted) where possible.

It also moves the commands to a shared `const` array, so it keeps the whitelist in a single spot.