### PR TITLE
Add a check to ensure stale entries in formattedDiagnosticsStore are deleted

### DIFF
--- a/apps/vscode-extension/src/diagnostics.ts
+++ b/apps/vscode-extension/src/diagnostics.ts
@@ -52,10 +52,17 @@ export function registerOnDidChangeDiagnostics(context: ExtensionContext) {
                 )
               );
 
-              // TODO: we should check if never deleting the entries is a performance issue
-              //       probably not, since solving all diagnostics for a file should set its value to an empty collection, but we should check anyway
-              //       see: https://github.com/yoavbls/pretty-ts-errors/issues/139
-              formattedDiagnosticsStore.set(uri.fsPath, items);
+              if (items.length === 0) {
+                logger.trace(
+                  `no diagnostics for ${uri.toString(true)}, removing from store`
+                );
+                formattedDiagnosticsStore.delete(uri.fsPath);
+              } else {
+                logger.trace(
+                  `storing ${items.length} formatted diagnostics for ${uri.toString(true)}`
+                );
+                formattedDiagnosticsStore.set(uri.fsPath, items);
+              }
 
               if (items.length > 0) {
                 ensureHoverProviderIsRegistered(uri, context);


### PR DESCRIPTION
Fixes a TODO comment to ensure stale entries in `formattedDiagnosticsStore` are deleted. Also adds `trace` log statements to improve bug reports.