### PR TITLE
feat: add Brazilian Portuguese (pt-BR) localization

### DIFF
--- a/apps/vscode-extension/l10n/bundle.l10n.pt-BR.json
+++ b/apps/vscode-extension/l10n/bundle.l10n.pt-BR.json
@@ -1,0 +1,14 @@
+{
+  "See detailed explanation": "Ver explicação detalhada",
+  "Show error in sidebar": "Mostrar erro na barra lateral",
+  "Pin error": "Fixar erro",
+  "Copy error to clipboard": "Copiar erro para a área de transferência",
+  "See translation": "Ver tradução",
+  "Error": "Erro",
+  "Select code with an error to show the prettified diagnostic in this view.": "Selecione um código com erro para exibir o diagnóstico formatado nesta visualização.",
+  "Pinned error": "Erro fixado",
+  "Unpin error": "Desafixar erro",
+  "This item is pinned on top.": "Este item está fixado acima.",
+  "Copied error message to clipboard!": "Mensagem de erro copiada para a área de transferência!",
+  "Copied type to clipboard!": "Tipo copiado para a área de transferência!"
+}

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -43,6 +43,7 @@
     "onLanguage:glimmer-js",
     "onLanguage:glimmer-ts"
   ],
+  "l10n": "./l10n",
   "main": "./dist/extension.js",
   "browser": "./dist/extension.js",
   "files": [

--- a/apps/vscode-extension/src/commands/copyError.ts
+++ b/apps/vscode-extension/src/commands/copyError.ts
@@ -1,4 +1,4 @@
-import { commands, env, window, type ExtensionContext } from "vscode";
+import { commands, env, l10n, window, type ExtensionContext } from "vscode";
 import { execute } from "./execute";
 
 const COMMAND_ID = "prettyTsErrors.copyError";
@@ -13,7 +13,7 @@ export function registerCopyError(context: ExtensionContext) {
           });
         }
         await env.clipboard.writeText(errorMessage);
-        window.showInformationMessage("Copied error message to clipboard!");
+        window.showInformationMessage(l10n.t("Copied error message to clipboard!"));
       })
     )
   );

--- a/apps/vscode-extension/src/commands/copyError.ts
+++ b/apps/vscode-extension/src/commands/copyError.ts
@@ -13,7 +13,9 @@ export function registerCopyError(context: ExtensionContext) {
           });
         }
         await env.clipboard.writeText(errorMessage);
-        window.showInformationMessage(l10n.t("Copied error message to clipboard!"));
+        window.showInformationMessage(
+          l10n.t("Copied error message to clipboard!")
+        );
       })
     )
   );

--- a/apps/vscode-extension/src/provider/markdownWebviewProvider.ts
+++ b/apps/vscode-extension/src/provider/markdownWebviewProvider.ts
@@ -57,7 +57,11 @@ export class MarkdownWebviewProvider {
     classList: string[] = []
   ): Promise<string> {
     const template = await this.webviewHtmlTemplate;
-    const html = this.patchCspSafeAttrs(template, webview);
+    let html = this.patchCspSafeAttrs(template, webview);
+    const i18nScript = `<script>window.__i18n=${JSON.stringify({
+      copiedTypeToClipboard: vscode.l10n.t("Copied type to clipboard!"),
+    })};</script>`;
+    html = html.replace("</head>", `${i18nScript}</head>`);
     return html.replace(
       '<div id="content"></div>',
       `<div id="content" class="${classList.join(" ")}">${content}</div>`

--- a/apps/vscode-extension/src/provider/webviewViewProvider.ts
+++ b/apps/vscode-extension/src/provider/webviewViewProvider.ts
@@ -20,8 +20,10 @@ import {
 import { SUPPORTED_LANGUAGE_IDS } from "../supportedLanguageIds";
 import { logger } from "../logger";
 
-const NO_DIAGNOSTICS_MESSAGE =
-  "Select code with an error to show the prettified diagnostic in this view.";
+const NO_DIAGNOSTICS_MESSAGE = () =>
+  vscode.l10n.t(
+    "Select code with an error to show the prettified diagnostic in this view."
+  );
 
 const SIDEBAR_CACHE_SIZE_MAX = 100;
 const sidebarHtmlCache = new Map<string, string>();
@@ -328,7 +330,7 @@ class MarkdownWebviewViewProvider implements vscode.WebviewViewProvider {
 
   private async getActiveContentHtml(): Promise<string> {
     const items = await this.getActiveDiagnosticItems();
-    if (items.length === 0) return NO_DIAGNOSTICS_MESSAGE;
+    if (items.length === 0) return NO_DIAGNOSTICS_MESSAGE();
     return items.map((item) => item.html).join("<hr>");
   }
 
@@ -367,9 +369,9 @@ class MarkdownWebviewViewProvider implements vscode.WebviewViewProvider {
           `<div class="pinned-header">` +
           `<span class="pinned-label">` +
           `<span class="codicon codicon-pinned"></span>` +
-          ` Pinned error` +
+          ` ${vscode.l10n.t("Pinned error")}` +
           `</span>` +
-          `<a class="unpin-button codicon codicon-close" title="Unpin error" href="command:prettyTsErrors.unpinError"></a>` +
+          `<a class="unpin-button codicon codicon-close" title="${vscode.l10n.t("Unpin error")}" href="command:prettyTsErrors.unpinError"></a>` +
           `</div>` +
           this.pinnedError.html +
           `</div>`
@@ -380,7 +382,7 @@ class MarkdownWebviewViewProvider implements vscode.WebviewViewProvider {
     // Render active diagnostic items
     const items = await this.getActiveDiagnosticItems();
     if (items.length === 0) {
-      sections.push(NO_DIAGNOSTICS_MESSAGE);
+      sections.push(NO_DIAGNOSTICS_MESSAGE());
     } else {
       for (let i = 0; i < items.length; i++) {
         if (i > 0) sections.push(`<hr>`);
@@ -388,7 +390,7 @@ class MarkdownWebviewViewProvider implements vscode.WebviewViewProvider {
         if (this.pinnedError && item.html === this.pinnedError.html) {
           sections.push(
             `<div class="diagnostic-item pinned-message">` +
-              `<em>This item is pinned on top.</em>` +
+              `<em>${vscode.l10n.t("This item is pinned on top.")}</em>` +
               `</div>`
           );
         } else {

--- a/apps/vscode-extension/webview/index.js
+++ b/apps/vscode-extension/webview/index.js
@@ -71,5 +71,7 @@ function handleCopyContentEvent(element) {
  */
 async function copyToClipboard(text) {
   await navigator.clipboard.writeText(text);
-  api.notify("Copied type to clipboard!");
+  api.notify(
+    window.__i18n?.copiedTypeToClipboard ?? "Copied type to clipboard!"
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,6 +2069,12 @@
       "dev": true,
       "license": "CC-BY-4.0"
     },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -8192,6 +8198,7 @@
       "dependencies": {
         "@pretty-ts-errors/formatter": "*",
         "@pretty-ts-errors/utils": "*",
+        "@vscode/l10n": "^0.0.18",
         "lz-string": "^1.5.0",
         "vscode-languageserver-types": "^3.17.5",
         "vscode-uri": "^3.1.0"

--- a/packages/vscode-formatter/package.json
+++ b/packages/vscode-formatter/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@pretty-ts-errors/formatter": "*",
     "@pretty-ts-errors/utils": "*",
+    "@vscode/l10n": "^0.0.18",
     "lz-string": "^1.5.0",
     "vscode-languageserver-types": "^3.17.5",
     "vscode-uri": "^3.1.0"

--- a/packages/vscode-formatter/src/components/actions.ts
+++ b/packages/vscode-formatter/src/components/actions.ts
@@ -1,12 +1,13 @@
 import { compressToEncodedURIComponent } from "lz-string";
 import { Diagnostic, Range } from "vscode-languageserver-types";
 import { d } from "@pretty-ts-errors/utils";
+import { t as l10nT } from "@vscode/l10n";
 
 export const divider = `<span class="divider">|</span>`;
 
 export const errorCodeExplanationLink = (errorCode: Diagnostic["code"]) =>
   d /*html*/ `
-    <a title="See detailed explanation" href="https://typescript.tv/errors/ts${errorCode}">
+    <a title="${l10nT("See detailed explanation")}" href="https://typescript.tv/errors/ts${errorCode}">
       <span class="codicon codicon-link-external">
       </span>
     </a>`;
@@ -16,7 +17,7 @@ export const showErrorInSidebarLink = (range: Range, message?: string) => {
     JSON.stringify(message != null ? [range, message] : [range])
   );
   return d /*html*/ `
-    <a title="Show error in sidebar" href="command:prettyTsErrors.showErrorInSidebar?${args}">
+    <a title="${l10nT("Show error in sidebar")}" href="command:prettyTsErrors.showErrorInSidebar?${args}">
       <span class="codicon codicon-layout-sidebar-left-dock">
       </span>
     </a>`;
@@ -27,7 +28,7 @@ export const pinErrorLink = (range: Range, message?: string) => {
     JSON.stringify(message != null ? [range, message] : [range])
   );
   return d /*html*/ `
-    <a title="Pin error" href="command:prettyTsErrors.pinError?${args}">
+    <a title="${l10nT("Pin error")}" href="command:prettyTsErrors.pinError?${args}">
       <span class="codicon codicon-pinned">
       </span>
     </a>`;
@@ -36,7 +37,7 @@ export const pinErrorLink = (range: Range, message?: string) => {
 export const copyErrorLink = (message: Diagnostic["message"]) => {
   const args = encodeURIComponent(JSON.stringify(message));
   return d /*html*/ `
-    <a title="Copy error to clipboard" href="command:prettyTsErrors.copyError?${args}">
+    <a title="${l10nT("Copy error to clipboard")}" href="command:prettyTsErrors.copyError?${args}">
       <span class="codicon codicon-copy">
       </span>
     </a>`;
@@ -45,7 +46,7 @@ export const copyErrorLink = (message: Diagnostic["message"]) => {
 export const errorMessageTranslationLink = (message: Diagnostic["message"]) => {
   const encodedMessage = compressToEncodedURIComponent(message);
   return d /*html*/ `
-    <a title="See translation" href="https://ts-error-translator.vercel.app/?error=${encodedMessage}">
+    <a title="${l10nT("See translation")}" href="https://ts-error-translator.vercel.app/?error=${encodedMessage}">
       <span class="codicon codicon-globe">
       </span>
     </a>`;

--- a/packages/vscode-formatter/src/components/errorTitle.ts
+++ b/packages/vscode-formatter/src/components/errorTitle.ts
@@ -1,12 +1,13 @@
 import { d } from "@pretty-ts-errors/utils";
 import { Diagnostic } from "vscode-languageserver-types";
+import { t as l10nT } from "@vscode/l10n";
 
 export const errorTitle = (
   code: Diagnostic["code"],
   actions: string,
   suffix = ""
 ) => d /*html*/ `
-    <span style="color:#f96363;">⚠ Error </span>${
+    <span style="color:#f96363;">⚠ ${l10nT("Error")} </span>${
       typeof code === "number"
         ? d /*html*/ `
             <span style="color:#5f5f5f;">


### PR DESCRIPTION
## Summary

Adds full Brazilian Portuguese (pt-BR) i18n support using the standard `@vscode/l10n` API (available since VS Code 1.73).

## What changed

- **`apps/vscode-extension/package.json`** — added `"l10n": "./l10n"` so VS Code auto-loads locale bundles
- **`packages/vscode-formatter/package.json`** — added `@vscode/l10n` dependency
- **`apps/vscode-extension/l10n/bundle.l10n.pt-BR.json`** — 12 translated strings (new file)
- **`packages/vscode-formatter/src/components/actions.ts`** — wrapped 5 tooltip titles with `l10nT()`
- **`packages/vscode-formatter/src/components/errorTitle.ts`** — wrapped "Error" label
- **`apps/vscode-extension/src/provider/webviewViewProvider.ts`** — wrapped 4 UI strings
- **`apps/vscode-extension/src/commands/copyError.ts`** — wrapped clipboard notification
- **`apps/vscode-extension/src/provider/markdownWebviewProvider.ts`** — injects `window.__i18n` into webview HTML with translated strings
- **`apps/vscode-extension/webview/index.js`** — reads from `window.__i18n` (webview has no direct access to VS Code l10n API)

## How it works

VS Code detects the user's display language and automatically loads the matching `bundle.l10n.{locale}.json` from the `l10n/` folder declared in `package.json`. No configuration needed by the user. Falls back to English for any other locale.

Adding support for additional languages only requires a new `bundle.l10n.{locale}.json` file — no code changes needed.

## Test plan

- [ ] Set VS Code display language to `pt-BR` (`Configure Display Language` command)
- [ ] Open a TypeScript file with a type error
- [ ] Verify hover tooltip shows "⚠ Erro" and translated action titles
- [ ] Open the side panel and verify empty state message is in Portuguese
- [ ] Pin an error and verify "Erro fixado" / "Desafixar erro" labels
- [ ] Click copy button and verify "Tipo copiado para a área de transferência!" notification