### PR TITLE
perf(errorMessagePrettifier): narrow regex match range

### DIFF
--- a/packages/formatter/src/errorMessagePrettifier.ts
+++ b/packages/formatter/src/errorMessagePrettifier.ts
@@ -125,9 +125,9 @@ async function getRules(codeBlock: CodeBlockFn): Promise<Rule[]> {
     },
     {
       pattern:
-        /(.*)['“]([^>]*)['”] (type|interface|return type|file|module|is (not )?assignable)/gi,
-      replacer: async (p1: string, p2: string, p3: string) =>
-        `${p1}${await formatTypeOrModuleBlock("", p2)} ${p3}`,
+        /['“]([^>]*)['”] (type|interface|return type|file|module|is (not )?assignable)/gi,
+      replacer: async (p1: string, p2: string) =>
+        `${await formatTypeOrModuleBlock("", p1)} ${p2}`,
     },
     {
       pattern:


### PR DESCRIPTION
related: https://github.com/yoavbls/pretty-ts-errors/issues/139

The `(.*)` at the beginning of the regular expression on `packages/formatter/src/errorMessagePrettifier.ts#L128` was matching characters that were passed through unchanged (just concatenated as-is to the output).

https://github.com/yoavbls/pretty-ts-errors/blob/b1ca17d500b1fa5e4699b29db4405850311890a6/packages/formatter/src/errorMessagePrettifier.ts#L128

In this PR, I improved inefficient matching by narrowing the match to cover only the portion that is actually transformed.
