### PR TITLE
fix: copy original diagnostic message

### DIFF
--- a/packages/vscode-formatter/src/format/prettifyDiagnosticForHover.ts
+++ b/packages/vscode-formatter/src/format/prettifyDiagnosticForHover.ts
@@ -34,7 +34,7 @@ export async function prettifyDiagnosticForHover(
       newDiagnostic.code,
       d`${showErrorInSidebarLink(newDiagnostic.range, diagnostic.message)} ${divider}
         ${pinErrorLink(newDiagnostic.range, diagnostic.message)} ${divider}
-        ${copyErrorLink(newDiagnostic.message)} ${divider}
+        ${copyErrorLink(diagnostic.message)} ${divider}
         ${errorCodeExplanationLink(newDiagnostic.code)}`,
       miniLine
     )}

--- a/packages/vscode-formatter/src/format/prettifyDiagnosticForSidebar.ts
+++ b/packages/vscode-formatter/src/format/prettifyDiagnosticForSidebar.ts
@@ -32,7 +32,7 @@ export async function prettifyDiagnosticForSidebar(
     ${errorTitle(
       newDiagnostic.code,
       d`${pinErrorLink(newDiagnostic.range, diagnostic.message)} ${divider}
-        ${copyErrorLink(newDiagnostic.message)} ${divider}
+        ${copyErrorLink(diagnostic.message)} ${divider}
         ${errorMessageTranslationLink(newDiagnostic.message)} ${divider}
         ${errorCodeExplanationLink(newDiagnostic.code)}`
     )}


### PR DESCRIPTION
## Summary
- Pass the original TypeScript diagnostic message to the copy-error action in hover and sidebar output
- Keep symbol-link enriched messages only for rendered/translation content, so clipboard text no longer includes the rendered HTML link markup

Fixes #220

## Validation
- npm run build --workspace @pretty-ts-errors/utils
- npm run build --workspace @pretty-ts-errors/formatter
- npm run build --workspace @pretty-ts-errors/vscode-formatter
- npm run lint --workspace @pretty-ts-errors/vscode-formatter
- npm run test --workspace @pretty-ts-errors/vscode-formatter

Note: full `npm run test` starts the VS Code extension integration test and cannot complete in this headless cron environment because Electron reports `Missing X server or $DISPLAY`.