### PR TITLE
fix: prevent diagnostic cache collisions

### DIFF
--- a/apps/vscode-extension/src/diagnostics.ts
+++ b/apps/vscode-extension/src/diagnostics.ts
@@ -1,5 +1,8 @@
 import { has } from "@pretty-ts-errors/utils";
-import { prettifyDiagnosticForHover } from "@pretty-ts-errors/vscode-formatter";
+import {
+  getDiagnosticCacheKey,
+  prettifyDiagnosticForHover,
+} from "@pretty-ts-errors/vscode-formatter";
 import {
   ExtensionContext,
   languages,
@@ -103,8 +106,9 @@ async function getFormattedDiagnostic(
   // formatDiagnosticForHover converts message based on LSP Diagnostic type, not VSCode Diagnostic type, so it can be used in other IDEs.
   // Here we convert VSCode Diagnostic to LSP Diagnostic to make formatDiagnosticForHover recognize it.
   const lspDiagnostic = converter.asDiagnostic(diagnostic);
+  const cacheKey = getDiagnosticCacheKey(lspDiagnostic);
 
-  let formattedMessage = cache.get(diagnostic.message);
+  let formattedMessage = cache.get(cacheKey);
   if (!formattedMessage) {
     const formattedDiagnostic = await prettifyDiagnosticForHover(lspDiagnostic);
     const markdownString = new MarkdownString(formattedDiagnostic);
@@ -117,7 +121,7 @@ async function getFormattedDiagnostic(
       const firstCacheKey = cache.keys().next().value!;
       cache.delete(firstCacheKey);
     }
-    cache.set(diagnostic.message, formattedMessage);
+    cache.set(cacheKey, formattedMessage);
   }
 
   return {

--- a/apps/vscode-extension/src/provider/webviewViewProvider.ts
+++ b/apps/vscode-extension/src/provider/webviewViewProvider.ts
@@ -14,6 +14,7 @@ import {
 } from "../formattedDiagnosticsStore";
 import { has } from "@pretty-ts-errors/utils";
 import {
+  getDiagnosticCacheKey,
   prettifyDiagnosticForSidebar,
   initHighlighter,
 } from "@pretty-ts-errors/vscode-formatter";
@@ -81,7 +82,7 @@ export function registerWebviewViewProvider(context: ExtensionContext) {
 async function diagnosticToItem(
   formattedDiagnostic: FormattedDiagnostic
 ): Promise<DiagnosticItem> {
-  const cacheKey = formattedDiagnostic.lspDiagnostic.message;
+  const cacheKey = getDiagnosticCacheKey(formattedDiagnostic.lspDiagnostic);
   let html = sidebarHtmlCache.get(cacheKey);
   if (!html) {
     html = await prettifyDiagnosticForSidebar(

--- a/packages/vscode-formatter/src/format/getDiagnosticCacheKey.ts
+++ b/packages/vscode-formatter/src/format/getDiagnosticCacheKey.ts
@@ -1,0 +1,26 @@
+import type { Diagnostic, Range } from "vscode-languageserver-types";
+
+function serializeRange(range: Range) {
+  return [
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character,
+  ];
+}
+
+/**
+ * Creates a stable cache key from every diagnostic field used by the formatter.
+ */
+export function getDiagnosticCacheKey(diagnostic: Diagnostic): string {
+  return JSON.stringify([
+    diagnostic.message,
+    serializeRange(diagnostic.range),
+    diagnostic.code,
+    (diagnostic.relatedInformation ?? []).map((information) => [
+      information.message,
+      information.location.uri,
+      serializeRange(information.location.range),
+    ]),
+  ]);
+}

--- a/packages/vscode-formatter/src/index.ts
+++ b/packages/vscode-formatter/src/index.ts
@@ -1,3 +1,4 @@
 export { prettifyDiagnosticForHover } from "./format/prettifyDiagnosticForHover";
 export { prettifyDiagnosticForSidebar } from "./format/prettifyDiagnosticForSidebar";
+export { getDiagnosticCacheKey } from "./format/getDiagnosticCacheKey";
 export { initHighlighter } from "./components/htmlCodeBlock";

--- a/packages/vscode-formatter/test/getDiagnosticCacheKey.vitest.ts
+++ b/packages/vscode-formatter/test/getDiagnosticCacheKey.vitest.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "vscode-languageserver-types";
+import { getDiagnosticCacheKey } from "../src";
+
+const diagnostic: Diagnostic = {
+  message: "Type 'Person' is not assignable to type 'Person'",
+  range: {
+    start: { line: 1, character: 2 },
+    end: { line: 1, character: 8 },
+  },
+  code: 2322,
+  relatedInformation: [
+    {
+      message: "'Person' is declared here.",
+      location: {
+        uri: "file:///person.ts",
+        range: {
+          start: { line: 3, character: 4 },
+          end: { line: 3, character: 10 },
+        },
+      },
+    },
+  ],
+};
+
+describe("getDiagnosticCacheKey", () => {
+  it("reuses the key for identical diagnostics", () => {
+    const identicalDiagnostic: Diagnostic = {
+      relatedInformation: diagnostic.relatedInformation,
+      code: diagnostic.code,
+      range: diagnostic.range,
+      message: diagnostic.message,
+    };
+
+    expect(getDiagnosticCacheKey(identicalDiagnostic)).toBe(
+      getDiagnosticCacheKey(diagnostic)
+    );
+  });
+
+  it.each([
+    {
+      field: "range",
+      changedDiagnostic: {
+        ...diagnostic,
+        range: {
+          ...diagnostic.range,
+          start: { line: 2, character: 2 },
+        },
+      },
+    },
+    {
+      field: "code",
+      changedDiagnostic: {
+        ...diagnostic,
+        code: 2345,
+      },
+    },
+    {
+      field: "related information URI",
+      changedDiagnostic: {
+        ...diagnostic,
+        relatedInformation: [
+          {
+            ...diagnostic.relatedInformation![0]!,
+            location: {
+              ...diagnostic.relatedInformation![0]!.location,
+              uri: "file:///another-person.ts",
+            },
+          },
+        ],
+      },
+    },
+  ])(
+    "does not collide when only the $field differs",
+    ({ changedDiagnostic }) => {
+      expect(getDiagnosticCacheKey(changedDiagnostic)).not.toBe(
+        getDiagnosticCacheKey(diagnostic)
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- derive cache keys from the diagnostic fields used by the formatter
- use the shared key for both hover and sidebar caches
- cover collisions caused by different ranges, codes, and related-information URIs

Fixes #143.

## Validation

- `npm run test -w @pretty-ts-errors/vscode-formatter`
- `npm run test -w @pretty-ts-errors/core`
- `npm run build`
- `npm run lint`
- `npm run format:check`

The VS Code extension harness also completed successfully once; a later repeated launch encountered VS Code 1.77 macOS long-socket-path cleanup behavior after the Vitest suites passed.

Assisted by OpenAI Codex. The change was independently reviewed against the issue and formatter call paths.